### PR TITLE
Add update_parameters option

### DIFF
--- a/ssm_parameter.tf
+++ b/ssm_parameter.tf
@@ -2,9 +2,13 @@
 resource "aws_ssm_parameter" "miamioh_data" {
   for_each = local.resource_parameters
 
-  lifecycle {
-    prevent_destroy = true
-    ignore_changes  = [value]
+  dynamic "lifecycle" {
+    for_each = range(var.update_parameters ? 0 : 1)
+
+    content {
+      prevent_destroy = true
+      ignore_changes  = [value]
+    }
   }
 
   name  = "/${join("/", compact([join("-", compact([each.value.environment, each.value.share])), trimprefix(each.value.path, "/"), each.value.name]))}"

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "manage_parameters" {
   description = "Whether or not to precreate and manage the ssm_parameters"
 }
 
+variable "update_parameters" {
+  type        = bool
+  default     = false
+  description = "Whether or not to override changes and allow destroy on the ssm_parameters - only useful when manage_parameters"
+}
+
 variable "environment" {
   type        = string
   description = "The environment used. 'all' may be used here instead if the secret is the same in all environments"


### PR DESCRIPTION
Handle the case of wanting terraform to manage and update a parameter rather than allowing aws console updates to remain.